### PR TITLE
Fix addLibrary call

### DIFF
--- a/khafile.js
+++ b/khafile.js
@@ -1,6 +1,6 @@
 let project = new Project('T Player');
 
-project.addLibrary('kha2d');
+project.addLibrary('Kha2D');
 
 project.addAssets('Assets/**', {
 	background: {


### PR DESCRIPTION
The call is currently broken on Linux (and probably osx) because it looks for `Libraries/kha2d` instead of `Libraries/Kha2D`.